### PR TITLE
Removed unused response

### DIFF
--- a/adopt-a-pup/notification-service/src/main/java/com/redhat/do328/adoptApup/notificationservice/NotificationController.java
+++ b/adopt-a-pup/notification-service/src/main/java/com/redhat/do328/adoptApup/notificationservice/NotificationController.java
@@ -17,7 +17,7 @@ public class NotificationController {
     private EmailManagerService emailManagerService;
 
     @RequestMapping(method = RequestMethod.POST, value = "/sendEmails")
-    public NotificationStatusResponse registerAnimalNotification(@RequestBody EmailNotificationRequest emailNotificationRequest) {
-        return emailManagerService.sendEmails(emailNotificationRequest);
+    public void registerAnimalNotification(@RequestBody EmailNotificationRequest emailNotificationRequest) {
+        emailManagerService.sendEmails(emailNotificationRequest);
     }
 }


### PR DESCRIPTION
The `adoption` service is not using the response from the `/sendEmails` and parsing the response in the `adoption` service seems that is not working like it should. For those reasons I think that we can remove the response.

An image with this fix is available: `quay.io/psolarvi/ossm-notification-service:beta` (I will remove the image as soon as this PR is merged)