### PR TITLE
Removed MongoDB from adoption and notification services

### DIFF
--- a/adopt-a-pup/adoption-service/pom.xml
+++ b/adopt-a-pup/adoption-service/pom.xml
@@ -37,10 +37,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-mongodb</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 

--- a/adopt-a-pup/adoption-service/src/main/java/com/redhat/do328/adoptApup/adoptionservice/model/Animal.java
+++ b/adopt-a-pup/adoption-service/src/main/java/com/redhat/do328/adoptApup/adoptionservice/model/Animal.java
@@ -3,15 +3,11 @@ package com.redhat.do328.adoptApup.adoptionservice.model;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.mapping.Document;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-@Document(collection = "animals")
 public class Animal {
-    @Id
     private String animalId;
     private String animalName;
     private String shelterId;

--- a/adopt-a-pup/adoption-service/src/main/java/com/redhat/do328/adoptApup/adoptionservice/model/Shelter.java
+++ b/adopt-a-pup/adoption-service/src/main/java/com/redhat/do328/adoptApup/adoptionservice/model/Shelter.java
@@ -3,16 +3,11 @@ package com.redhat.do328.adoptApup.adoptionservice.model;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.mapping.Document;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-@Document(collection = "shelters")
 public class Shelter {
-
-    @Id
     private String shelterId;
     private String shelterName;
     private String state;

--- a/adopt-a-pup/adoption-service/src/main/resources/application.properties
+++ b/adopt-a-pup/adoption-service/src/main/resources/application.properties
@@ -1,9 +1,3 @@
 notificationService.host=http://notification-service:8080
 animalService.host=http://animal-service:8080
 shelterService.host=http://shelter-service:8080
-spring.data.mongodb.host=mongodb
-spring.data.mongodb.database=adopt-a-pup
-spring.data.mongodb.password=developer
-spring.data.mongodb.username=developer
-
-

--- a/adopt-a-pup/notification-service/pom.xml
+++ b/adopt-a-pup/notification-service/pom.xml
@@ -42,10 +42,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-mongodb</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 

--- a/adopt-a-pup/notification-service/src/main/resources/application.properties
+++ b/adopt-a-pup/notification-service/src/main/resources/application.properties
@@ -1,7 +1,3 @@
 spring.mail.host=email-service
 spring.mail.port=25
 spring.mail.properties.mail.transport.protocol=smtp
-spring.data.mongodb.host=mongodb
-spring.data.mongodb.database=adopt-a-pup
-spring.data.mongodb.password=developer
-spring.data.mongodb.username=developer


### PR DESCRIPTION
Seems like we don't need MongoDB in the following services:
- `adoption`
- `notification`

The reason to remove it is because we will be restricting the access to MongoDB to only specific services. 

Please feel free to update the PR with any other MobgoDB stuff we need to remove from the `adoption` && `notification` services. 